### PR TITLE
Added support for multiple students per question

### DIFF
--- a/ui/src/message_popup/mobile_prototype/message_components.jsx
+++ b/ui/src/message_popup/mobile_prototype/message_components.jsx
@@ -15,7 +15,7 @@ const Message = React.createClass({
     text: React.PropTypes.string.isRequired,
     messageStyle: React.PropTypes.object.isRequired,
     messageTextStyle: React.PropTypes.object.isRequired,
-    question: React.PropTypes.object,
+    student: React.PropTypes.object,
     onOpenDialog: React.PropTypes.func
   },
   
@@ -45,9 +45,9 @@ const Message = React.createClass({
           </IconButton>
         }
         <div style={styles.messageTextSection}>
-          {this.props.question !== undefined && 
+          {this.props.student !== undefined && 
             <div style={styles.studentName}>
-              {this.props.question.student.name}
+              {this.props.student.name}
             </div>
           }
           <Paper style={messageTextStyle}>{this.props.text}</Paper>
@@ -65,7 +65,7 @@ const Message = React.createClass({
 export const StudentMessage = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
-    question: React.PropTypes.object,
+    student: React.PropTypes.object,
     onOpenStudentDialog: React.PropTypes.func.isRequired
   },
   
@@ -78,7 +78,7 @@ export const StudentMessage = React.createClass({
         <Message 
           type="student"
           text={this.props.text}
-          question={this.props.question}
+          student={this.props.student}
           messageStyle={messageStyle}
           messageTextStyle={messageTextStyle}
           onOpenDialog={this.props.onOpenStudentDialog}
@@ -114,7 +114,6 @@ export const UserMessage = React.createClass({
 export const InfoMessage = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
-    question: React.PropTypes.object,
     onOpenInfoDialog: React.PropTypes.func.isRequired
   },
   

--- a/ui/src/message_popup/mobile_prototype/texting_interface.jsx
+++ b/ui/src/message_popup/mobile_prototype/texting_interface.jsx
@@ -26,7 +26,7 @@ export const TextBody = React.createClass({
           if(message.type === 'user'){
             return (<UserMessage text={message.text}  key={message.key} />);
           }else if(message.type === 'student'){
-            return (<StudentMessage text={message.text} question={this.props.question} onOpenStudentDialog={this.props.onOpenStudentDialog} key={message.key} />);
+            return (<StudentMessage text={message.text} student={message.student} onOpenStudentDialog={this.props.onOpenStudentDialog(message.student)} key={message.key} />);
           }else{
             return (<InfoMessage text={message.text} onOpenInfoDialog={this.props.onOpenInfoDialog} key={message.key} />);
           }

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -39,7 +39,7 @@ export default React.createClass({
       text: React.PropTypes.string.isRequired,
       examples: React.PropTypes.array.isRequired,
       nonExamples: React.PropTypes.array.isRequired,
-      student: React.PropTypes.object
+      students: React.PropTypes.array
     }).isRequired,
     onLog: React.PropTypes.func.isRequired,
     onDone: React.PropTypes.func.isRequired,
@@ -156,8 +156,9 @@ export default React.createClass({
   renderQuestion(){
     const {elapsedMs} = this.state;
     const {scaffolding} = this.props;
-    const {text, student, examples, nonExamples} = this.props.question;
+    const {text, students, examples, nonExamples} = this.props.question;
     const seconds = Math.round(elapsedMs / 1000);
+    const student = students[0];
     
     return (
       <div>

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -23,7 +23,7 @@ function forIndicator(indicatorId) {
 }
 
 export type Question = {
-  studentId?: number,
+  studentIds?: [number],
   id: number,
   text: string,
   examples: [string],
@@ -31,10 +31,10 @@ export type Question = {
 };
 export const inquiryQuestions:[Question] = [
   { 
-    studentId: 4, 
+    studentIds: [4], 
     id: 101,
     text: `At the conclusion of your lesson plan for this challenge, you seed a group discussion by asking "What are you curious about related to photosynthesis?"  Hayin says "Why are plants green?"  What do you do?`,
-    encodedText: `[:i]At the conclusion of your lesson plan for this challenge, you seed a group discussion.[:u]What are you curious about related to photosynthesis?[:s]Why are plants green?`,
+    encodedText: `[:i]At the conclusion of your lesson plan for this challenge, you seed a group discussion.[:u]What are you curious about related to photosynthesis?[:4s]Why are plants green?`,
     examples: [
       `"We spent some time already studying that question, is there something else you're curious about, or how can you take that question to the next level?"`,
       `"Oh, are all plants green?"`,
@@ -49,10 +49,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },  
   {
-    studentId: 10, 
+    studentIds: [10], 
     id: 102,
     text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what's happening.  She asks "what is photosynthesis again?"  How can you give a brief direct answer to her question?`,
-    encodedText: `[:i]Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what's happening.[:s]What is photosynthesis again?[:i]How can you give a brief direct answer to her question?`,
+    encodedText: `[:i]Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what's happening.[:10s]What is photosynthesis again?[:i]How can you give a brief direct answer to her question?`,
     examples: [
       `"Photosynthesis is the process where plants take in sunlight and carbon dioxide from the air, and produce sugar they can use and breathe out oxygen." [Candidate might use intonation or guestures]`,
       `"Maia, this is Sasha. Sasha, this is Maia. Maia, will you take a couple minutes to help Sasha learn about photosynthesis. If you two have any questions, call me back over."`,
@@ -66,10 +66,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   { 
-    studentId: 2, 
+    studentIds: [2], 
     id: 103,
     text: `In the context of the lesson plan you developed for this challenge, Floyd says "why are we even doing this?"  Respond in way that engages his natural curiosity and tendency towards asking questions`,
-    encodedText: `[:i]In the context of the lesson plan you developed for this challenge...[:s]Why are we even doing this?[:i]Respond in way that engages his natural curiosity and tendency towards asking questions.`,
+    encodedText: `[:i]In the context of the lesson plan you developed for this challenge...[:2s]Why are we even doing this?[:i]Respond in way that engages his natural curiosity and tendency towards asking questions.`,
     examples: [
       `"Well, imagine what would happen if there was no sunlight."`,
       `"If we'll all going to live on Mars by the time you're an adult, we're going to have to figure out how plants can grow up there."`,
@@ -83,10 +83,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 8,
+    studentIds: [8],
     id: 104,
     text: `Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.  Ada says "How many questions should I write and what do you want me to include in them?"  Respond in a way that draws out the student's curiosity and pushes them towards asking questions that are meaningful to them.`,
-    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.[:s]How many questions should I write and what do you want me to include in them?[:i]Respond in a way that draws out the student's curiosity and pushes them towards asking questions that are meaningful to them.`,
+    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.[:8s]How many questions should I write and what do you want me to include in them?[:i]Respond in a way that draws out the student's curiosity and pushes them towards asking questions that are meaningful to them.`,
     examples: [
       '"Right now come up with as many ideas as you can, then we will build on those ideas for the next step."',
       '"I really appreciated your ideas during the last discussion, and know you\'ll have great ones here too."',
@@ -104,10 +104,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 10,
+    studentIds: [10],
     id: 105,
     text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what's happening at the beginning of the class.  She interrupts and asks, "I do better with visuals, can you draw me a picture of photosynthesis?"  Describe what you could quickly sketch to directly answer her question.`,
-    encodedText: `[:i]Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what's happening at the beginning of the class.[:s]I do better with visuals, can you draw me a picture of photosynthesis?[:i]Describe what you could quickly sketch to directly answer her question.`,
+    encodedText: `[:i]Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what's happening at the beginning of the class.[:10s]I do better with visuals, can you draw me a picture of photosynthesis?[:i]Describe what you could quickly sketch to directly answer her question.`,
     examples: [
       `[Insert simple drawings here]`
     ],
@@ -117,10 +117,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 3,
+    studentIds: [3],
     id: 106,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.  Maia asks "How can plants be breathing, you don't see them inhaling and exhaling, and you don't see their breath in the cold?"`,
-    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.[:s]How can plants be breathing, you don't see them inhaling and exhaling, and you don't see their breath in the cold?`,
+    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.[:3s]How can plants be breathing, you don't see them inhaling and exhaling, and you don't see their breath in the cold?`,
     examples: [
       `"Well, is there a difference in scale?  Think of everything that's happening on your skin, but you can't see individual bacteria without a microscope."`,
       `"Great question. How can set up an experiment to test out if plants really breathe?"`,
@@ -131,10 +131,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 5,
+    studentIds: [5],
     id: 107,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Mike asks, "I'm still a little confused, can you explain it again in a different way?"`,
-    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.[:s]I'm still a little confused, can you explain it again in a different way?`,
+    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.[:5s]I'm still a little confused, can you explain it again in a different way?`,
     examples: [
       `"Plants need to breathe and eat just like we do, and like all living things do.  Photosynthesis is like the process of you digesting your food, and your body giving you energy from it."`,
       `"OK, everyone turn to a partner. Work together to come up with your own short explanation of photosynthesis. Draw or write explanation on your small whiteboard. Everyone will hold up their whiteboards when we're done to share our ideas."`,
@@ -146,10 +146,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 2,
+    studentIds: [2],
     id: 108,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Floyd asks, "But how can plants take in sunlight, do they like grab it?"`,
-    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.[:s]But how can plants take in sunlight, do they like grab it?`,
+    encodedText: `[:i]Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.[:2s]But how can plants take in sunlight, do they like grab it?`,
     examples: [
       `"They absorb the light, yeah.  It's just like when you're outside in the sun, your skin absorbs the sunlight.  Your skin gets warmer, and if you're out there too long then you might even get sunburnt from absorbing too much of the sunlight energy."`,
       `"What do you mean by grab? Can anyone else share another word that may help explain how plants take in sunlight?"`,
@@ -161,10 +161,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 9,
+    studentIds: [9],
     id: 109,
     text: 'You challenge Steve and ask, "What is another hypothesis you could test?" He asks, "why don\'t you just tell me what the right answer is?"',
-    encodedText: '[:i]You challenge Steve.[:u]What is another hypothesis you could test?[:s]Why don\'t you just tell me what the right answer is?',
+    encodedText: '[:i]You challenge Steve.[:u]What is another hypothesis you could test?[:9s]Why don\'t you just tell me what the right answer is?',
     examples: [
       'Discuss that scientific inquiry often starts when there is no clear right answer.',
       'Discuss that scientists ask questions about things they are interested in.',
@@ -191,10 +191,10 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 1,
+    studentIds: [1],
     id: 111,
     text: 'You set up an experiment that tests how light intensity affects photosynthesis over time and recorded the data. Kevin says, "Plant A probably grew more because it was genetically modified by Home Depot," and the whole class laughs. Prompt the student to clarify and use evidence.',
-    encodedText: '[:i]You set up an experiment that tests how light intensity affects photosynthesis over time and recorded the data.[:s]Plant A probably grew more because it was genetically modified by Home Depot[:i]The whole class laughs. Prompt the student to clarify and use evidence.',
+    encodedText: '[:i]You set up an experiment that tests how light intensity affects photosynthesis over time and recorded the data.[:1s]Plant A probably grew more because it was genetically modified by Home Depot[:i]The whole class laughs. Prompt the student to clarify and use evidence.',
     examples: [
       'Ask the student to make claims using evidence',
       `That's a great point! Genetically modified plants are going to be a part of our lives. I'm curious - do you think Home Depot would genetically modify a plant? Could you clarify your ideas a little more?`,
@@ -205,7 +205,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 6,
+    studentIds: [6],
     id: 112,
     text: `As you walk around, you see that Jasmine is missing some data in their data tables. What could you do to nudge her in the right direction?`,
     encodedText: `[:i]As you walk around, you see that Jasmine is missing some data in their data tables. What could you do to nudge her in the right direction?`,
@@ -220,7 +220,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 7,
+    studentIds: [7],
     id: 113,
     text: 'Miquel finished generating questions (i.e. hypotheses) about photosynthesis, and some are not testable. How can you connect his responses with the idea of planning research?',
     encodedText: '[:i]Miquel finished generating questions (i.e. hypotheses) about photosynthesis, and some are not testable. How can you connect his responses with the idea of planning research?',
@@ -232,7 +232,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 5,
+    studentIds: [5],
     id: 114,
     text: `You set up a photosynthesis experiment for the class, and students report the data they\'ve collected. As it turns out, Mike has experimented with only two variables: hours of light and water.  Respond to this by connecting this with data collection planning.`,
     encodedText: `[:i]You set up a photosynthesis experiment for the class, and students report the data they\'ve collected. As it turns out, Mike has experimented with only two variables: hours of light and water.  Respond to this by connecting this with data collection planning.`,
@@ -248,10 +248,10 @@ export const inquiryQuestions:[Question] = [
 
 export const motivationQuestions:[Question] = [
   {
-    studentId: 8,
+    studentIds: [8],
     id: 115,
     text: 'Ada is frustrated that she cannot figure out how her data supports her initial hypothesis. She refuses to modify her question, instead saying, "I don\'t want to try again because I will just mess up again."',
-    encodedText: '[:i]Ada is frustrated that she cannot figure out how her data supports her initial hypothesis. She refuses to modify her question.[:s]I don\'t want to try again because I will just mess up again.',
+    encodedText: '[:i]Ada is frustrated that she cannot figure out how her data supports her initial hypothesis. She refuses to modify her question.[:8s]I don\'t want to try again because I will just mess up again.',
     examples: [
       'Try the principle: Persisting through challenges is how we grow (Duckworth)',
       'Try the principle: Project to students that you believe they can be successful (Expectancy)'
@@ -259,10 +259,10 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 3,
+    studentIds: [3, 8],
     id: 116,
-    text: 'At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand and says, "I don\'t want to do any of these. Can I just come up with my own thing?" Even before you have a chance to respond to her, another student, another student, says, "I want to do my own topic too!"  Respond.',
-    encodedText: '[:i]At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand.[:s]I don\'t want to do any of these. Can I just come up with my own thing?[:i]Even before you have a chance to respond to her, another student, another student, says, "I want to do my own topic too!"  Respond.',
+    text: 'At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand and says, "I don\'t want to do any of these. Can I just come up with my own thing?" Even before you have a chance to respond to her, another student says, "I want to do my own topic too!"  Respond.',
+    encodedText: '[:i]At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand.[:3s]I don\'t want to do any of these. Can I just come up with my own thing?[:i]Even before you have a chance to respond to her, another student raises her hand. [:8s]I want to do my own topic too!',
     examples: [
       'Try the principle: Interest-powered learning',
       'Try the principle: Encourage choice (Glasser)'
@@ -270,10 +270,10 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 8,
+    studentIds: [8, 5],
     id: 117,
     text: 'Students are working individually on a worksheet. You notice that a student is distracted.  She lashes out, "I can\'t do this! And Mike gets it. He just gets science and I don\'t. Why do I even need to try?"',
-    encodedText: '[:i]Students are working individually on a worksheet. You notice that a student is distracted.[:s]I can\'t do this! And Mike gets it. He just gets science and I don\'t. Why do I even need to try?',
+    encodedText: '[:i]Students are working individually on a worksheet. You notice that a student is distracted.[:8s]I can\'t do this! And Mike gets it. He just gets science and I don\'t. Why do I even need to try?',
     examples: [
       'Try the principle: Everyone has the capacity to grow (Dweck)',
       'Try the principle: Persisting through challenges is how we grow (Duckworth)'
@@ -292,7 +292,7 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 10,
+    studentIds: [10],
     id: 119,
     text: 'You divide students into groups to perform a photosynthesis experiment. Students get to divide themselves into groups. A new student, Sasha, doesn\'t get picked until the last minute.  What would you do?',
     encodedText: '[:i]You divide students into groups to perform a photosynthesis experiment. Students get to divide themselves into groups. A new student, Sasha, doesn\'t get picked until the last minute.  What would you do?',
@@ -303,10 +303,10 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 3,
+    studentIds: [3, 1],
     id: 120,
     text: 'You introduced a game related to photosynthesis, and have pairs of two working on a game. Maia is paired with Kevin, and she asks, "How are we getting graded on this?" You tell her that there will be no grade for either completion or participation. "Why are we doing this then?" she asks.',
-    encodedText: '[:i]You introduced a game related to photosynthesis, and have pairs of two working on a game. Maia is paired with Kevin.[:s]How are we getting graded on this?[:u]There will be no grade for either completion or participation.[:s]Why are we doing this then?',
+    encodedText: '[:i]You introduced a game related to photosynthesis, and have pairs of two working on a game. Maia is paired with Kevin.[:3s]How are we getting graded on this?[:u]There will be no grade for either completion or participation.[:3s]Why are we doing this then?',
     examples: [
       'Try the principle: Learning as the goal',
       'Try the principle: Outcome as the goal',

--- a/ui/src/message_popup/scoring_question_context.jsx
+++ b/ui/src/message_popup/scoring_question_context.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
             expandable={true}>
               <div>
                 <div style={{paddingBottom: 20}}>{question.text}</div>
-                {question.student && <StudentCard useCardStyles={true} student={question.student} />}
+                {question.students.map(student => <StudentCard useCardStyles={true} student={student} />)}
               </div>
           </CardText>
         </Card>

--- a/ui/src/message_popup/transformations.jsx
+++ b/ui/src/message_popup/transformations.jsx
@@ -8,8 +8,13 @@ import {allQuestions} from './questions.js';
 
 export function withStudents(questions) {
   return questions.map((question) => {
-    const student = _.find(allStudents, {id: question.studentId });
-    return _.extend({student}, question);
+    var students = [];
+    if(_.has(question, 'studentIds')){
+      for (var studentIdIndex = 0; studentIdIndex < question.studentIds.length; studentIdIndex++){
+        students.push(_.find((allStudents), {id: question.studentIds[studentIdIndex]}));
+      }
+    }
+    return _.extend({students}, question);
   });
 }
 


### PR DESCRIPTION
Questions can now support multiple students. Instead of a `studentId`, there is now the `studentIds` parameter. `studentIds` is just an array of what would have gone in studentId. To encode different students speaking, you would follow the normal encodings of `[:i]`, `[:u]` but `[:s]` changed to `[:{id}s]`. For example, if student with ID 1 (Kevin) was speaking, the encoding would look like this `[:1s]`. For an example of this in the code, refer to question 116.
